### PR TITLE
Issue#4 diminuer taille grille

### DIFF
--- a/dual_and_back_app.py
+++ b/dual_and_back_app.py
@@ -70,7 +70,12 @@ class DualAndBackApp:
         # Cadre la grille
         self.grid_frame = tk.Frame(self.master, bg=self.bg_color)
         self.grid_frame.place(
-            relx=0.5, rely=0.5, anchor=tk.CENTER, width=grid_width, height=grid_height
+            relx=0.5,
+            rely=0,
+            anchor=tk.N,
+            y=50,
+            width=grid_width,
+            height=grid_height,  #  anchor=tk.N --> N is for north -- y=50 --> adds a 50px padding
         )
 
         # Creation d'une grille de 3x3 via Canvas


### PR DESCRIPTION
Apres test la grille de 3x3 est maintenant ancree sur le haut du jeu, laissant de la place pour deplacer les boutons de jeu (POSITION et SOUND).  

Pour cela, j'ai : 
- passe la proportion de la grille de 0.65 a 0.5
- et ai ajoute un padding de 50px sur le haut pour que la grille ne finisse pas par se coller sur le bord du haut  

![image](https://github.com/user-attachments/assets/5831c208-6ae3-47d2-82bd-5b38a1e25864)


